### PR TITLE
make removing last satellite more robust

### DIFF
--- a/src/modules/util/CesiumCleanupHelper.js
+++ b/src/modules/util/CesiumCleanupHelper.js
@@ -8,12 +8,19 @@ export class CesiumCleanupHelper {
       console.info("Removing leftover Cesium internal data");
       onTickEventRemovalCallback();
 
-      const labelCollection = viewer.scene.primitives?._primitives[0]?._primitives[0]._primitives[0]._labelCollection;
-      if (labelCollection) {
-        labelCollection._spareBillboards.forEach((billboard) => {
-          labelCollection._billboardCollection.remove(billboard);
-        });
-        labelCollection._spareBillboards.length = 0;
+      try {
+        const primitives = viewer.scene.primitives?._primitives;
+        const labelCollection = primitives?.[0]?._primitives?.[0]?._primitives?.[0]?._labelCollection;
+        if (labelCollection && labelCollection._spareBillboards && labelCollection._billboardCollection) {
+          labelCollection._spareBillboards.forEach((billboard) => {
+            if (billboard) {
+              labelCollection._billboardCollection.remove(billboard);
+            }
+          });
+          labelCollection._spareBillboards.length = 0;
+        }
+      } catch (e) {
+        console.warn("CesiumCleanupHelper: Could not clean up internal data", e);
       }
     });
   }


### PR DESCRIPTION
When removing the last satellite the following error pops up

<img width="943" height="357" alt="image" src="https://github.com/user-attachments/assets/fd8ec237-901d-4397-b82c-fca0ef5207ab" />

This MR fixes it by handling this a bit more gracefully