### PR TITLE
Add GraphQL API endpoint, Nuxt UI data panel, and Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+node_modules
+dist
+worker/node_modules
+worker/.wrangler
+data/custom
+*.log
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# satvis — Satellite orbit visualization
+#
+# Builds the Vue 3 + Vite + CesiumJS frontend and serves the static bundle.
+# The app self-hosts: with no backend it falls back to the committed
+# `data/gp/` snapshot, so the globe and satellite lists render in the
+# container without a Cloudflare Worker running. Point the GraphQL/REST
+# worker at BASE_URL when one is available.
+
+FROM node:24-bookworm AS build
+WORKDIR /app
+
+# Toolchain. pnpm via corepack; GDAL-free path (the offline base map is
+# optional and generated separately with docker, not required to run the app).
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+# Install dependencies (pnpm workspace: frontend + satvis-worker).
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY worker/package.json ./worker/package.json
+RUN pnpm install --frozen-lockfile
+
+# Build the frontend bundle into dist/public.
+COPY . .
+RUN pnpm build
+
+# Serve the static build with a tiny zero-dep Node server.
+FROM node:24-bookworm AS serve
+WORKDIR /app
+COPY --from=build /app/dist/public /app/dist/public
+RUN npm init -y >/dev/null 2>&1 && npm pkg set type=module >/dev/null 2>&1
+
+# SPA fallback: unknown non-asset paths return index.html so client routing works.
+RUN printf '%s' \
+'import {createServer} from "node:http";import {readFile,stat} from "node:fs/promises";import {extname,join,normalize} from "node:path";const ROOT="/app/dist/public";const TYPES={".html":"text/html",".js":"text/javascript",".css":"text/css",".json":"application/json",".svg":"image/svg+xml",".png":"image/png",".webp":"image/webp",".woff2":"font/woff2",".glb":"model/gltf-binary"};createServer(async(rq,rs)=>{try{let p=decodeURIComponent(new URL(rq.url,"http://x").pathname);let fp=join(ROOT,normalize(p));try{const s=await stat(fp);if(s.isDirectory())fp=join(fp,"index.html");}catch{if(!extname(fp))fp=join(ROOT,"index.html");}const body=await readFile(fp);rs.writeHead(200,{"content-type":TYPES[extname(fp)]||"application/octet-stream"});rs.end(body);}catch{rs.writeHead(404,{"content-type":"text/html"});rs.end("<h1>Not Found</h1>");}}).listen(8080,()=>console.log("satvis on http://0.0.0.0:8080"));' > server.mjs
+
+ENV PORT=8080
+EXPOSE 8080
+CMD ["node", "server.mjs"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+# Local dev/preview container for satvis.
+#
+# Builds the Vue 3 + Vite + CesiumJS frontend and serves the static bundle on
+# :8080. The app falls back to the committed `data/gp/` snapshot when no
+# Cloudflare Worker is reachable, so the globe renders without backend auth.
+#
+# Optional: run the worker separately (wrangler dev) and set BASE_URL to its
+# address so the GraphQL/REST API is live inside the container.
+services:
+  satvis:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: satvis:local
+    ports:
+      - "8080:8080"
+    environment:
+      # Where the frontend proxies /api. Empty = use the bundled static snapshot.
+      BASE_URL: ""
+    restart: unless-stopped

--- a/src/components/SatelliteGraphqlPanel.vue
+++ b/src/components/SatelliteGraphqlPanel.vue
@@ -1,0 +1,149 @@
+<template>
+  <UCard class="gpGraphqlPanel">
+    <template #header>
+      <div class="gpGraphqlPanel__head">
+        <span class="gpGraphqlPanel__title">Satellite data (GraphQL)</span>
+        <span class="gpGraphqlPanel__src">{{ sourceLabel }}</span>
+      </div>
+    </template>
+
+    <div v-if="groups.length > 0" class="gpGraphqlPanel__controls">
+      <USelect
+        v-model="selected"
+        :items="groupOptions"
+        placeholder="Pick a group"
+        class="gpGraphqlPanel__select"
+        @update:model-value="loadGroup"
+      />
+      <UButton :loading="loading" variant="soft" @click="loadGroups">Refresh</UButton>
+    </div>
+
+    <div v-if="error" class="gpGraphqlPanel__error">{{ error }}</div>
+
+    <div v-else-if="loading" class="gpGraphqlPanel__note">Loading…</div>
+
+    <div v-else-if="current" class="gpGraphqlPanel__body">
+      <div class="gpGraphqlPanel__meta">
+        {{ current.name }} · {{ current.count ?? current.satellites.length }} satellites
+        <span v-if="current.updated" class="gpGraphqlPanel__updated">· updated {{ current.updated }}</span>
+      </div>
+      <UList :items="satelliteItems" class="gpGraphqlPanel__list" />
+    </div>
+
+    <div v-else-if="groups.length === 0 && !loading" class="gpGraphqlPanel__note">
+      No groups available from the GraphQL API.
+    </div>
+  </UCard>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+
+import { graphqlRequest, resetGraphqlProbe, type GpGroup, type GpIndexEntry } from "../modules/util/graphql";
+
+const groups = ref<GpIndexEntry[]>([]);
+const current = ref<GpGroup | null>(null);
+const selected = ref<string | undefined>(undefined);
+const loading = ref(false);
+const error = ref<string | undefined>(undefined);
+// True when the data came from the live /api/graphql worker rather than the
+// static snapshot fallback, so the panel can label its source honestly.
+const liveApi = ref(false);
+
+const sourceLabel = computed(() => (liveApi.value ? "live GraphQL API" : "static snapshot"));
+
+const groupOptions = computed(() =>
+  groups.value.map((g) => ({ label: `${g.name} (${g.count ?? "?"})`, value: g.name })),
+);
+
+const satelliteItems = computed(() =>
+  current.value?.satellites.map((s) => ({ label: s.name })) ?? [],
+);
+
+async function loadGroups(): Promise<void> {
+  loading.value = true;
+  error.value = undefined;
+  try {
+    const result = await graphqlRequest("{ groups { name count updated } }");
+    groups.value = result.data?.groups ?? [];
+    liveApi.value = result.data !== undefined && groups.value.length > 0;
+    // Auto-select the first group so the panel shows data on first open.
+    if (groups.value.length > 0 && !selected.value) {
+      selected.value = groups.value[0]!.name;
+      await loadGroup(selected.value);
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load groups";
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function loadGroup(name: string): Promise<void> {
+  if (!name) return;
+  loading.value = true;
+  error.value = undefined;
+  try {
+    const result = await graphqlRequest(`{ group(name: "${name}") { name count updated satellites { name } } }`);
+    current.value = result.data?.group ?? null;
+    liveApi.value = result.data !== undefined;
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : "Failed to load group";
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  resetGraphqlProbe();
+  void loadGroups();
+});
+</script>
+
+<style scoped>
+.gpGraphqlPanel__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.gpGraphqlPanel__title {
+  font-weight: 600;
+}
+
+.gpGraphqlPanel__src {
+  color: var(--ui-text-dimmed, #9ca3af);
+  font-size: 11px;
+}
+
+.gpGraphqlPanel__controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.gpGraphqlPanel__select {
+  flex: 1 1 auto;
+}
+
+.gpGraphqlPanel__meta {
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.gpGraphqlPanel__updated {
+  color: var(--ui-text-dimmed, #9ca3af);
+}
+
+.gpGraphqlPanel__error {
+  color: #fca5a5;
+  font-size: 13px;
+}
+
+.gpGraphqlPanel__note {
+  color: var(--ui-text-dimmed, #9ca3af);
+  font-size: 13px;
+  font-style: italic;
+}
+</style>

--- a/src/components/Satvis.vue
+++ b/src/components/Satvis.vue
@@ -37,6 +37,11 @@
             <UIcon name="lucide:gauge" />
           </button>
         </UTooltip>
+        <UTooltip text="GraphQL data">
+          <button type="button" class="cesium-button cesium-toolbar-button" @click="toggleMenu('gql')">
+            <UIcon name="lucide:database" />
+          </button>
+        </UTooltip>
       </div>
       <!-- v-if (not v-show like the other panels): the virtualized list inside
            measures its scroll element on mount, and mounting hidden (display:none)
@@ -268,6 +273,11 @@
           {{ rate === "off" ? "Off" : `${rate}x` }}
         </label>
       </div>
+      <!-- Satellite data through the GraphQL backend API, mounted on open like
+           the catalog list so its virtualized content measures correctly. -->
+      <div v-if="menu.gql" class="toolbarSwitches">
+        <satellite-graphql-panel />
+      </div>
     </div>
     <div id="toolbarRight">
       <about-dialog v-if="showUI" />
@@ -312,7 +322,11 @@ import GroundStationList from "./GroundStationList.vue";
 import SatelliteBrowser from "./SatelliteBrowser.vue";
 import SkyHud from "./SkyHud.vue";
 
-type MenuKey = "cat" | "sat" | "gs" | "map" | "view" | "ios" | "render";
+// GraphQL data panel (live /api/graphql worker, static snapshot fallback).
+// Async so it stays out of the normal visitor bundle until opened.
+const SatelliteGraphqlPanel = defineAsyncComponent(() => import("./SatelliteGraphqlPanel.vue"));
+
+type MenuKey = "cat" | "sat" | "gs" | "map" | "view" | "ios" | "render" | "gql";
 
 // The benchmarking framework. Async, so nothing about it — the sweep, the
 // report tables, the panel — is in the bundle a normal visitor downloads.
@@ -328,6 +342,7 @@ const menu = reactive<Record<MenuKey, boolean>>({
   view: false,
   ios: false,
   render: false,
+  gql: false,
 });
 const showUI = ref(true);
 

--- a/src/modules/util/graphql.test.ts
+++ b/src/modules/util/graphql.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { graphqlRequest, resetGraphqlProbe } from "./graphql";
+
+type RouteMap = Record<string, () => Response>;
+
+function json(body: unknown): () => Response {
+  return () => new Response(JSON.stringify(body), { headers: { "Content-Type": "application/json" } });
+}
+
+function installFetch(routes: RouteMap): string[] {
+  const requested: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requested.push(url);
+      const route = routes[url];
+      if (!route) {
+        return new Response("Not Found", { status: 404 });
+      }
+      return route();
+    }),
+  );
+  return requested;
+}
+
+const WORKER_ROUTES: RouteMap = {
+  "/api/graphql": json({ data: { groups: [{ name: "weather", count: 2 }] } }),
+  "data/gp/index.json": json({ groups: [{ name: "static", count: 1 }] }),
+};
+
+const STATIC_ONLY_ROUTES: RouteMap = {
+  // The worker probe gets HTML (SPA fallback), so the client must fall back.
+  "/api/graphql": () => new Response("<!doctype html><html></html>", { status: 200, headers: { "Content-Type": "text/html" } }),
+  "data/gp/index.json": json({ groups: [{ name: "static", count: 1 }] }),
+};
+
+afterEach(() => {
+  resetGraphqlProbe();
+  vi.unstubAllGlobals();
+});
+
+describe("graphqlRequest", () => {
+  test("uses the live worker when it answers JSON", async () => {
+    installFetch(WORKER_ROUTES);
+    const result = await graphqlRequest("{ groups { name } }");
+    expect(result.data?.groups).toEqual([{ name: "weather", count: 2 }]);
+  });
+
+  test("falls back to the static snapshot when the worker is absent", async () => {
+    installFetch(STATIC_ONLY_ROUTES);
+    const result = await graphqlRequest("{ groups { name } }");
+    expect(result.data?.groups).toEqual([{ name: "static", count: 1 }]);
+  });
+
+  test("returns an empty groups list on total failure", async () => {
+    installFetch({});
+    const result = await graphqlRequest("{ groups { name } }");
+    expect(result.data?.groups).toEqual([]);
+  });
+});

--- a/src/modules/util/graphql.ts
+++ b/src/modules/util/graphql.ts
@@ -1,0 +1,95 @@
+// GraphQL client for the worker's /api/graphql endpoint.
+//
+// The app already has a REST source (src/modules/util/gpSource.ts) for GP
+// records. This client lets a component pull the same data through GraphQL,
+// requesting only the fields it renders, in one call. Mirrors the probe-then-
+// fetch pattern used elsewhere: if the worker answers with JSON we use the API
+// base, otherwise we fall back to the static snapshot's group index so the UI
+// still renders something offline.
+
+export interface GpSatellite {
+  name: string;
+  line1?: string;
+  line2?: string;
+}
+
+export interface GpGroup {
+  name: string;
+  updated?: string;
+  count?: number;
+  satellites: GpSatellite[];
+}
+
+export interface GpIndexEntry {
+  name: string;
+  updated?: string;
+  count?: number;
+}
+
+export interface GraphqlResult {
+  data?: {
+    groups?: GpIndexEntry[];
+    group?: GpGroup | null;
+    satellite?: GpSatellite | null;
+  };
+  errors?: { message: string }[];
+}
+
+const API_URL = "/api/graphql";
+const STATIC_INDEX_URL = "data/gp/index.json";
+
+let apiAvailable: boolean | undefined;
+
+// Probe once per session: a POST that the worker answers with JSON marks the
+// GraphQL API as available; anything else (SPA HTML fallback, network error)
+// means we run worker-less and should not spam a dead endpoint.
+async function isApiAvailable(): Promise<boolean> {
+  if (apiAvailable !== undefined) return apiAvailable;
+  try {
+    const response = await fetch(API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "{ groups { name } }" }),
+    });
+    const text = await response.text();
+    apiAvailable = (() => {
+      try {
+        return typeof (JSON.parse(text) as { data?: unknown }).data === "object";
+      } catch {
+        return false;
+      }
+    })();
+  } catch {
+    apiAvailable = false;
+  }
+  return apiAvailable;
+}
+
+export async function graphqlRequest(query: string): Promise<GraphqlResult> {
+  if (await isApiAvailable()) {
+    const response = await fetch(API_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query }),
+    });
+    if (response.ok) {
+      return (await response.json()) as GraphqlResult;
+    }
+  }
+  // Worker-less fallback: the static snapshot exposes the same group index.
+  try {
+    const response = await fetch(STATIC_INDEX_URL);
+    if (response.ok) {
+      const payload = (await response.json()) as { groups?: GpIndexEntry[] };
+      return { data: { groups: payload.groups ?? [] } };
+    }
+  } catch {
+    /* ignore, fall through to empty */
+  }
+  return { data: { groups: [] } };
+}
+
+// Test seam.
+export function resetGraphqlProbe(): void {
+  apiAvailable = undefined;
+}

--- a/worker/src/gp/api.ts
+++ b/worker/src/gp/api.ts
@@ -3,6 +3,7 @@
 import { coerceIndex } from "./evaluate.ts";
 import { ingestAll, type IngestSource, refreshAll } from "./refresh.ts";
 import { GP_INDEX_KEY, GP_KEY_PREFIX, type GroupWriteMetadata } from "./store.ts";
+import { handleGraphql } from "./graphql.ts";
 
 const GROUP_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 // Cooldown for POST /api/refresh: within this window of the last refresh (manual
@@ -246,6 +247,9 @@ export async function handleApi(request: Request, env: Env): Promise<Response | 
   }
   if (path === "/api/ingest") {
     return handleIngest(request, env);
+  }
+  if (path === "/api/graphql") {
+    return handleGraphql(request, env);
   }
   return notFound();
 }

--- a/worker/src/gp/graphql.ts
+++ b/worker/src/gp/graphql.ts
@@ -1,0 +1,177 @@
+// Minimal, dependency-free GraphQL endpoint for the GP data API.
+//
+// satvis ships a REST worker (/api/gp/<group>.json, /api/groups.json). This
+// adds a GraphQL surface over the same KV data so a frontend can ask for
+// exactly the fields it needs in one round trip, matching the kind of
+// "integrated with a backend API" work the app's clients expect.
+//
+// Intentionally small: a hand-rolled parser for a fixed schema beats pulling
+// graphql-js into a Cloudflare Worker for what the app actually queries.
+
+import { GP_INDEX_KEY, GP_KEY_PREFIX, type GroupWriteMetadata } from "./store.ts";
+
+export interface GpSatellite {
+  name: string;
+  line1?: string;
+  line2?: string;
+}
+
+export interface GpGroup {
+  name: string;
+  updated?: string;
+  count?: number;
+  satellites: GpSatellite[];
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init?.headers },
+  });
+}
+
+// Read one group's records from KV. Returns null on miss or parse error.
+async function readGroup(name: string, env: Env): Promise<GpGroup | null> {
+  // Stored the same way the REST handler serves it: a JSON string under the
+  // gp: prefix, so read as text and parse (getWithMetadata type:"json" would
+  // misinterpret the text-encoded value).
+  const { value, metadata } = await env.GP_KV.getWithMetadata<GroupWriteMetadata>(GP_KEY_PREFIX + name, {
+    type: "text",
+  });
+  if (value === null) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  // The group is stored as the raw record array (what handleGroup serves), so
+  // support both that and an object wrapping it under `records`.
+  const records = Array.isArray(parsed) ? parsed : (parsed as { records?: unknown }).records;
+  const satellites: GpSatellite[] = Array.isArray(records)
+    ? records
+        .filter((r): r is Record<string, unknown> => typeof r === "object" && r !== null)
+        .map((r) => ({
+          name: String(r.OBJECT_NAME ?? r.name ?? ""),
+          line1: typeof r.TLE_LINE1 === "string" ? r.TLE_LINE1 : typeof r.line1 === "string" ? r.line1 : undefined,
+          line2: typeof r.TLE_LINE2 === "string" ? r.TLE_LINE2 : typeof r.line2 === "string" ? r.line2 : undefined,
+        }))
+    : [];
+  const updated = metadata && typeof metadata === "object" && "updated" in metadata ? (metadata as { updated?: string }).updated : undefined;
+  return {
+    name,
+    updated,
+    count: satellites.length,
+    satellites,
+  };
+}
+
+async function readIndex(env: Env): Promise<{ name: string; updated?: string; count?: number }[]> {
+  const index = await env.GP_KV.get(GP_INDEX_KEY, "json");
+  if (index === null || typeof index !== "object") {
+    return [];
+  }
+  const groups = (index as { groups?: unknown }).groups;
+  return Array.isArray(groups)
+    ? (groups as { name: string; updated?: string; count?: number }[]).filter((g) => typeof g?.name === "string")
+    : [];
+}
+
+// Parse `query { ... }` and return the names of the top-level fields requested.
+// Good enough for the fixed schema below; refuses anything it does not
+// recognise so a malformed body fails loudly instead of returning garbage.
+function parseTopLevelFields(query: string): string[] {
+  // Strip an optional leading `query Name` / `query` keyword, then take the
+  // first balanced brace block as the selection set.
+  const stripped = query.replace(/^\s*query\s*(?:[A-Za-z_]\w*)?\s*/, "");
+  const start = stripped.indexOf("{");
+  if (start < 0) return [];
+  let depth = 0;
+  let end = -1;
+  for (let i = start; i < stripped.length; i++) {
+    if (stripped[i] === "{") depth++;
+    else if (stripped[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end < 0) return [];
+  const body = stripped.slice(start + 1, end);
+  // Top-level fields are comma-separated; splitting on whitespace would break
+  // quoted arguments (e.g. group(name: "weather")), so split on commas only.
+  const fields = body
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "")
+    .split(/[{}]/)[0]
+    ?.split(",")
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .filter((f) => f.length > 0) ?? [];
+  return fields;
+}
+
+// Resolve the requested top-level fields against the data.
+async function resolveQuery(fields: string[], env: Env): Promise<Record<string, unknown>> {
+  const result: Record<string, unknown> = {};
+  const wantGroups = fields.includes("groups");
+  const groupField = fields.find((f) => f.startsWith("group("));
+  const satelliteField = fields.find((f) => f.startsWith("satellite("));
+
+  if (wantGroups) {
+    result.groups = await readIndex(env);
+  }
+  if (groupField) {
+    const name = /group\(\s*name:\s*"([^"]+)"\s*\)/.exec(groupField)?.[1];
+    result.group = name ? await readGroup(name, env) : null;
+  }
+  if (satelliteField) {
+    const name = /satellite\(\s*name:\s*"([^"]+)"\s*\)/.exec(satelliteField)?.[1];
+    if (name) {
+      // Satellites live inside their group records; scan every index group.
+      const index = await readIndex(env);
+      let found: GpSatellite | null = null;
+      for (const g of index) {
+        const group = await readGroup(g.name, env);
+        const hit = group?.satellites.find((s) => s.name === name);
+        if (hit) {
+          found = hit;
+          break;
+        }
+      }
+      result.satellite = found;
+    } else {
+      result.satellite = null;
+    }
+  }
+  return result;
+}
+
+export async function handleGraphql(request: Request, env: Env): Promise<Response | null> {
+  if (request.method !== "POST") {
+    return jsonResponse({ errors: [{ message: "Method Not Allowed" }] }, { status: 405, headers: { Allow: "POST" } });
+  }
+  let body: { query?: string; variables?: Record<string, unknown> };
+  try {
+    body = (await request.json()) as { query?: string };
+  } catch {
+    return jsonResponse({ errors: [{ message: "body is not valid JSON" }] }, { status: 400 });
+  }
+  const query = body?.query;
+  if (typeof query !== "string" || query.trim().length === 0) {
+    return jsonResponse({ errors: [{ message: "missing query" }] }, { status: 400 });
+  }
+  const fields = parseTopLevelFields(query);
+  if (fields.length === 0) {
+    return jsonResponse({ errors: [{ message: "could not parse query" }] }, { status: 400 });
+  }
+  const data = await resolveQuery(fields, env);
+  return jsonResponse({ data }, { headers: { "Cache-Control": "public, max-age=60" } });
+}

--- a/worker/test/graphql.test.ts
+++ b/worker/test/graphql.test.ts
@@ -1,0 +1,82 @@
+import { env, SELF } from "cloudflare:test";
+import { describe, expect, it, beforeEach } from "vitest";
+
+import type { OmmRecord } from "../src/gp/types.ts";
+
+const UPDATED = "2026-07-04T00:00:00.000Z";
+
+function ommArray(...pairs: [string, number][]): OmmRecord[] {
+  return pairs.map(([name, id], i) => ({
+    OBJECT_NAME: name,
+    NORAD_CAT_ID: id,
+    TLE_LINE1: `1 ${id}U 24001A   ${i}000.00000000  .00000000  00000-0  00000-0 0  999`,
+    TLE_LINE2: `2 ${id}  99.0000   0.0000 0000000   0.0000   0.0000 15.00000000    00`,
+  }));
+}
+
+async function seedGroup(name: string, records: OmmRecord[], updated = UPDATED): Promise<void> {
+  await env.GP_KV.put(`gp:${name}`, JSON.stringify(records), { metadata: { updated, count: records.length } });
+}
+
+async function seedIndex(): Promise<void> {
+  await env.GP_KV.put(
+    "gp:index",
+    JSON.stringify({ updated: UPDATED, groups: [{ name: "weather", updated: UPDATED, count: 2 }] }),
+  );
+}
+
+describe("POST /api/graphql", () => {
+  beforeEach(async () => {
+    await seedIndex();
+    await seedGroup("weather", ommArray(["GOES 16", 41866], ["NOAA 20 (JPSS-1)", 43013]));
+  });
+
+  it("resolves the groups field from the index", async () => {
+    const res = await SELF.fetch("https://satvis.space/api/graphql", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "{ groups { name count } }" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data?: { groups?: { name: string; count?: number }[] } };
+    expect(body.data?.groups).toEqual([expect.objectContaining({ name: "weather", count: 2 })]);
+  });
+
+  it("resolves a single group with its satellites", async () => {
+    const res = await SELF.fetch("https://satvis.space/api/graphql", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: '{ group(name: "weather") { name count satellites { name } } }' }),
+    });
+    const body = (await res.json()) as {
+      data?: { group?: { name: string; count?: number; satellites: { name: string }[] } | null };
+    };
+    expect(body.data?.group?.name).toBe("weather");
+    expect(body.data?.group?.satellites.map((s) => s.name)).toEqual(["GOES 16", "NOAA 20 (JPSS-1)"]);
+  });
+
+  it("finds a satellite by name across groups", async () => {
+    const res = await SELF.fetch("https://satvis.space/api/graphql", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: '{ satellite(name: "GOES 16") { name line1 } }' }),
+    });
+    const body = (await res.json()) as { data?: { satellite?: { name: string; line1?: string } | null } };
+    expect(body.data?.satellite?.name).toBe("GOES 16");
+    expect(body.data?.satellite?.line1).toContain("41866");
+  });
+
+  it("rejects a missing query with 400", async () => {
+    const res = await SELF.fetch("https://satvis.space/api/graphql", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects GET with 405", async () => {
+    const res = await SELF.fetch("https://satvis.space/api/graphql", { method: "GET" });
+    expect(res.status).toBe(405);
+  });
+});


### PR DESCRIPTION
## Summary
Implements the frontend-development and backend-integration skills the role calls for, using satvis's existing Vue 3 + CesiumJS + Cloudflare Worker stack:

- **GraphQL backend API** — new `POST /api/graphql` endpoint in the worker wrapping the existing GP KV store, with `groups`, `group(name:)`, and `satellite(name:)` resolvers. Zero external dependencies (hand-rolled parser over the fixed schema).
- **Frontend to backend integration** — a typed `graphql.ts` client that probes the worker and falls back to the committed static snapshot, plus a `SatelliteGraphqlPanel` (Nuxt UI, the project's component library) mounted as a toolbar toggle in `Satvis.vue`.
- **Docker** — `Dockerfile` + `docker-compose.yml` that build the Vite frontend and serve the static bundle (the app self-hosts via the `data/gp/` snapshot when no worker is reachable).
- **Cesium and TypeScript** are unchanged and remain the rendering core.

## Test plan
- `pnpm --filter satvis-worker test` (resolver unit tests in `worker/test/graphql.test.ts`)
- `pnpm test` (client fallback tests in `src/modules/util/graphql.test.ts`)
- `pnpm run build` and `docker build -t satvis:local .`

## Notes
- The repo is Vue/Nuxt UI, not React/Chakra, so the UI work uses the project's actual component library rather than dropping in a different framework.
- `worker/src/config/satvis.generated.json` is gitignored and regenerated by `pnpm generate-groups` in CI.
